### PR TITLE
Fixed typo in the last sentence.

### DIFF
--- a/content/blog/2018-08-03-bottender-0_15.md
+++ b/content/blog/2018-08-03-bottender-0_15.md
@@ -116,4 +116,4 @@ With our accumulative experiences from connector developing , we are confident t
 
 ### Serverless
 
-Experiments are currently held on some major cloud providers with Serverless service, such as AWS Lambda, Google Cloud Functions, and Azure Functions ect. This would reduce a decent amount of maintaining costs when running less frequently visited chatbot service and more importantly, no sacrifices are to be made when it comes to user expirience.
+Experiments are currently held on some major cloud providers with Serverless service, such as AWS Lambda, Google Cloud Functions, and Azure Functions ect. This would reduce a decent amount of maintaining costs when running less frequently visited chatbot service and more importantly, no sacrifices are to be made when it comes to user experience.


### PR DESCRIPTION
"user expirience" should be "user experience"